### PR TITLE
revise the code for findOne() by _id in server/record.js

### DIFF
--- a/mern/server/routes/record.js
+++ b/mern/server/routes/record.js
@@ -5,8 +5,13 @@ const express = require("express");
 // The router will be added as a middleware and will take control of requests starting with path /record.
 const recordRoutes = express.Router();
 
-//This will help us connect to the database
+// This will help us connect to the database
 const dbo = require("../db/conn");
+
+// This help convert the id from string to ObjectId for the _id.
+// Without the convert, findOne() by _id won't work.
+const ObjectId = require("mongodb").ObjectId;
+
 
 // This section will help you get a list of all the records.
 recordRoutes.route("/record").get(function (req, res) {
@@ -21,9 +26,13 @@ recordRoutes.route("/record").get(function (req, res) {
 });
 
 // This section will help you get a single record by id
+// _id should be used to find the record by id.
+// req.params.id should be used for identifying the record, 
+// because there is not any req.body.id passed from the front-end.
+// The 'employees' symbol should be removed, because the getDb() does not receive any params.
 recordRoutes.route("/record/:id").get(function (req, res) {
-  let db_connect = dbo.getDb("employees");
-  let myquery = { id: req.body.id };
+  let db_connect = dbo.getDb();
+  let myquery = { _id: ObjectId( req.params.id )};
   db_connect
       .collection("records")
       .findOne(myquery, function (err, result) {
@@ -33,8 +42,9 @@ recordRoutes.route("/record/:id").get(function (req, res) {
 });
 
 // This section will help you create a new record.
+// The 'employees' symbol should be removed, because the getDb() does not receive any params.
 recordRoutes.route("/record/add").post(function (req, res) {
-  let db_connect = dbo.getDb("employees");
+  let db_connect = dbo.getDb();
   let myobj = {
     person_name: req.body.person_name,
     person_position: req.body.person_position,
@@ -46,9 +56,13 @@ recordRoutes.route("/record/add").post(function (req, res) {
 });
 
 // This section will help you update a record by id.
+// _id should be used to find the record by id.
+// req.params.id should be used for identifying the record, 
+// because there is not any req.body.id passed from the front-end.
+// The 'employees' symbol should be removed, because the getDb() does not receive any params.
 recordRoutes.route("/update/:id").post(function (req, res) {
-  let db_connect = dbo.getDb("employees");
-  let myquery = { id: req.body.id };
+  let db_connect = dbo.getDb();
+  let myquery = { _id: ObjectId( req.params.id )};
   let newvalues = {
     $set: {
       person_name: req.body.person_name,
@@ -65,9 +79,11 @@ recordRoutes.route("/update/:id").post(function (req, res) {
 });
 
 // This section will help you delete a record
+// The 'employees' symbol should be removed, because the getDb() does not receive any params.
+
 recordRoutes.route("/:id").delete((req, res) => {
-  let db_connect = dbo.getDb("employees");
-  var myquery = { id: req.body.id };
+  let db_connect = dbo.getDb();
+  let myquery = { _id: ObjectId( req.params.id )};
   db_connect.collection("records").deleteOne(myquery, function (err, obj) {
     if (err) throw err;
     console.log("1 document deleted");


### PR DESCRIPTION
When I follow the tutorial [How to Use MERN Stack: A Complete Guide](https://www.mongodb.com/languages/mern-stack-tutorial) to build the app, I found a few issues to stop the app work properly, include missing the endpoint `get(/record/:id, function (req, res) { })` for entering the edit page, misuse id for _id with `mongodb` driver,  give the id the property without converting it to ObjectId, and an unnecessary parameter which passed to getDb(). 

When I fork this project, I found someone added the endpoint but the other issues are still there, so I ask this pull request for the rest of them.