### PR TITLE
Add a Node version disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Mern Stack code for the [Mern Tutorial](https://www.mongodb.com/languages/mern-s
 
 [![CI](https://github.com/mongodb-developer/mern-stack-example/actions/workflows/main.yaml/badge.svg)](https://github.com/mongodb-developer/mern-stack-example/actions/workflows/main.yaml)
 
+> Disclaimer: The React application works with Node.js 16 and below.
+
 ## How To Run
 Create an Atlas URI connection parameter in `mern/server/config.env` with your Atlas URI:
 ```


### PR DESCRIPTION
Added a disclaimer that the project only works with Node.js 16 and below. This is because of a security vulnerability fixed in Node.js 17. The fix breaks the version of `react-scripts` that this project is using. The disclaimer should be temporary until we update the repository.