### PR TITLE
chore: add Dockerfile and docker-compose for local development

### DIFF
--- a/mern/.dockerignore
+++ b/mern/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.gitignore
+node_modules/

--- a/mern/client/dockerfile
+++ b/mern/client/dockerfile
@@ -1,0 +1,22 @@
+# stage 1: build react frontend
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm ci --ignore-scripts
+
+COPY . .
+
+RUN npm run build
+
+#stage 2: serve with nginx
+FROM nginx:alpine
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/mern/client/nginx.conf
+++ b/mern/client/nginx.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+
+    # server the built react static files
+    location / {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        try_files $uri $uri/ /index.html;
+    }
+
+    # proxy layer: forward all /record API requests to the backend container
+    location /record {
+        proxy_pass http://backend:5050;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+}

--- a/mern/docker-compose.yaml
+++ b/mern/docker-compose.yaml
@@ -1,0 +1,42 @@
+version: '3.8'
+
+services:
+  database:
+    image: mongo:6-jammy
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_data:/data/db
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+
+
+  backend:
+    build: ./server
+    ports:
+      - "5050:5050"
+    environment:
+      - PORT=5050
+      - ATLAS_URI=mongodb://database:27017/my_mern_db
+    depends_on:
+      - database
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+
+  frontend:
+    build: ./client
+    ports:
+      - "3000:80"
+    depends_on:
+      - backend
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+
+volumes:
+  mongo_data: 

--- a/mern/server/dockerfile
+++ b/mern/server/dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm ci --omit=dev --ignore-scripts
+
+COPY . .
+
+USER node
+
+EXPOSE 5050
+
+CMD [ "npm", "start" ]


### PR DESCRIPTION
### Summary
This PR containerizes the MERN stack application using Docker and Docker Compose. It allows developers to spin up the entire local development environment (Frontend, Backend, and MongoDB) with a single command without needing to install dependencies locally.

### Changes Made
* Added `Dockerfile` for the React frontend (multi-stage build).
* Added `Dockerfile` for the Node.js/Express backend.
* Created a root-level `docker-compose.yml` file to orchestrate the services and the MongoDB database.
* Configured environment variables to ensure seamless local network communication between containers.

### How to Test Locally

1. Clone this repo
2. Ensure you have docker installed and running.
3. Change the directory to mern
4. Run the following command inside  directory:
   ```bash
   docker-compose up -d --build
   ```
5. Access the application in your browser:
   * Frontend: `http://localhost:3000`
   * Backend API: `http://localhost:5050`




