### PR TITLE
Read codespace telemetry URL from org secret

### DIFF
--- a/.devcontainer/track.sh
+++ b/.devcontainer/track.sh
@@ -2,7 +2,8 @@
 # Best-effort telemetry: log a codespace lifecycle event. Never fails the caller.
 EVENT="${1:-unknown}"
 GIT_EMAIL="$(git config --get user.email 2>/dev/null || true)"
-URL="https://us-central1-project-learning-fuel.cloudfunctions.net/trackCodespace"
+URL="${CODESPACE_TELEMETRY_URL:-}"
+[ -z "$URL" ] && exit 0
 curl -fsS -m 5 -X POST "$URL" \
   -H "Content-Type: application/json" \
   -d "{\"event\":\"$EVENT\",\"codespace\":\"${CODESPACE_NAME:-}\",\"user\":\"${GITHUB_USER:-}\",\"gitEmail\":\"${GIT_EMAIL:-}\",\"repository\":\"${GITHUB_REPOSITORY:-mongodb-developer/mern-stack-example}\"}" \


### PR DESCRIPTION
Replaces the hardcoded, publicly-exposed Cloud Function URL in `.devcontainer/track.sh` with a read from the `CODESPACE_TELEMETRY_URL` org Codespaces secret. The old guessable-name function has been deleted and redeployed under a random name; the new URL is only stored as a secret, never committed. The script no-ops (exits 0) if the secret isn't available, consistent with its existing best-effort behavior.