### PR TITLE
Add weekly scheduled CI run and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mongodb-developer/learning-fuel

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ main ]
   workflow_dispatch:
+  schedule:
+    - cron: '5 6 * * 1'
 
 jobs:
   build:
@@ -68,4 +70,44 @@ jobs:
           working-directory: mern/client
           start: npm run dev
           wait-on: 'http://localhost:5173'
-        
+
+  notify-on-failure:
+    needs: build
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: File or update CI failure issue for @mongodb-developer/learning-fuel
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = `CI failure on ${context.ref}`;
+            const body = [
+              '@mongodb-developer/learning-fuel the CI workflow failed.',
+              '',
+              `Workflow: ${context.workflow}`,
+              `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            ].join('\n');
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'ci-failure',
+            });
+            if (existing.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing[0].number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['ci-failure'],
+              });
+            }


### PR DESCRIPTION
## Summary
- Add a weekly `schedule` trigger (Mondays 06:05 UTC) to the existing CI workflow so tests run periodically, not just on push/PR
- Add `.github/CODEOWNERS` with `@mongodb-developer/learning-fuel` as owner (team has admin access to this repo)
- On CI failure, file/update a GitHub issue mentioning `@mongodb-developer/learning-fuel` so the team is notified

## Test plan
- [x] YAML validated (`yaml.safe_load`)
- [ ] Confirm the scheduled run and failure-notification job execute as expected once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)